### PR TITLE
Allow blank command line arguments

### DIFF
--- a/lib/cocaine/command_line.rb
+++ b/lib/cocaine/command_line.rb
@@ -78,9 +78,9 @@ module Cocaine
     end
 
     def shell_quote(string)
-      return "" if string.nil? or string.empty?
+      return "" if string.nil?
       if self.class.unix?
-        string.split("'").map{|m| "'#{m}'" }.join("\\'")
+        string.empty? ? "''" : string.split("'").map{|m| "'#{m}'" }.join("\\'")
       else
         %{"#{string}"}
       end

--- a/spec/cocaine/command_line_spec.rb
+++ b/spec/cocaine/command_line_spec.rb
@@ -65,6 +65,15 @@ describe Cocaine::CommandLine do
     cmd.command.should == %{convert "`rm -rf`.jpg" "ha'ha.png"}
   end
 
+  it "quotes blank values into the command line's parameters" do
+    cmd = Cocaine::CommandLine.new("curl",
+                                   "-X POST -d :data :url",
+                                   :data => "",
+                                   :url => "http://localhost:9000",
+                                   :swallow_stderr => false)
+    cmd.command.should == "curl -X POST -d '' 'http://localhost:9000'"
+  end
+
   it "allows colons in parameters" do
     cmd = Cocaine::CommandLine.new("convert", "'a.jpg' xc:black 'b.jpg'", :swallow_stderr => false)
     cmd.command.should == "convert 'a.jpg' xc:black 'b.jpg'"


### PR DESCRIPTION
Hi,

I was trying to pass an empty argument and noticed that Cocaine would ignore it. 

I'm uncertain if this is by design or not, but you should be able to do so. For example the following would not be valid without it (nor without the `--data` parameter for that matter):

`curl -X POST --data '' 'http://localhost:9900'`

The following patch addresses this issue (nil arguments are ignored as before).

Thanks,
Daniel
