### PR TITLE
Make available exit status

### DIFF
--- a/lib/cocaine/command_line.rb
+++ b/lib/cocaine/command_line.rb
@@ -4,6 +4,8 @@ module Cocaine
       attr_accessor :path, :logger
     end
 
+    attr_reader :exit_status
+
     def initialize(binary, params = "", options = {})
       @binary            = binary.dup
       @params            = params.dup
@@ -31,6 +33,8 @@ module Cocaine
         end
       rescue Errno::ENOENT
         raise Cocaine::CommandNotFoundError
+      ensure
+        @exit_status = $?.exitstatus
       end
       if $?.exitstatus == 127
         raise Cocaine::CommandNotFoundError

--- a/spec/cocaine/command_line_spec.rb
+++ b/spec/cocaine/command_line_spec.rb
@@ -142,6 +142,15 @@ describe Cocaine::CommandLine do
     end
   end
 
+  it "should keep result code in #exitstatus" do
+    cmd = Cocaine::CommandLine.new("convert")
+    cmd.class.stubs(:"`").with("convert").returns(:correct_value)
+    with_exitstatus_returning(1) do
+      cmd.run rescue nil
+    end
+    cmd.exit_status.should == 1
+  end
+
   it "detects that the system is unix" do
     Cocaine::CommandLine.new("convert").unix?.should be_true
   end


### PR DESCRIPTION
Add CommandLine#exit_status to make available exit status after a run.
