### PR TITLE
Fix swallow_stderr for windows/cygwin shells

### DIFF
--- a/lib/cocaine/command_line.rb
+++ b/lib/cocaine/command_line.rb
@@ -7,7 +7,7 @@ module Cocaine
     rescue LoadError => e
       # posix-spawn gem not available
     end
-    
+
     class << self
       attr_accessor :path, :logger
     end
@@ -61,6 +61,10 @@ module Cocaine
       return !ENV['SHELL'].nil?
     end
 
+    def cygwin?
+      (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/) and ENV['SHELL']
+    end
+
     private
 
     def with_modified_path
@@ -111,7 +115,13 @@ module Cocaine
     end
 
     def bit_bucket
-      unix? ? "2>/dev/null" : "2>NUL"
+      if cygwin?
+        "2>/dev/null"
+      elsif unix?
+        "&2>/dev/null"
+      else
+        "2>NUL"
+      end
     end
   end
 end

--- a/lib/cocaine/version.rb
+++ b/lib/cocaine/version.rb
@@ -1,3 +1,3 @@
 module Cocaine
-  VERSION = "0.2.1".freeze
+  VERSION = "0.2.2".freeze
 end


### PR DESCRIPTION
The `unix?` method didn't support windows/cygwin shells.  By making the test include looking for the SHELL environment variable, support is added (windows environment doesn't set this, so `echo %SHELL%` in a cmd.exe returns nil).  Thanks http://www.cyberciti.biz/tips/how-do-i-find-out-what-shell-im-using.html .

Also, I _think_ the `bit_bucket` should be `&2>/dev/null` for unix shells - without that, in windows/cygwin, I get a path-not-found, anyway.  I _assume_ that's the same for real unix shells.
