### PR TITLE
Depend on activesupport instead of active_support

### DIFF
--- a/cocaine.gemspec
+++ b/cocaine.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('bourne')
   s.add_development_dependency('mocha')
   s.add_development_dependency('rake')
-  s.add_development_dependency('activesupport', '~> 3.0')
+  s.add_development_dependency('activesupport', '~> 4.0')
   s.add_development_dependency('pry')
 end
 

--- a/spec/cocaine/command_line_spec.rb
+++ b/spec/cocaine/command_line_spec.rb
@@ -211,7 +211,7 @@ describe Cocaine::CommandLine do
 
   it 'can still take something that does not respond to tty as a logger' do
     output_buffer = StringIO.new
-    logger = ActiveSupport::BufferedLogger.new(output_buffer)
+    logger = ActiveSupport::Logger.new(output_buffer)
     logger.should_not respond_to(:tty?)
     Cocaine::CommandLine.new("echo", "'Logging!' :foo", :logger => logger).run(:foo => "bar")
     output_buffer.rewind


### PR DESCRIPTION
Limits the version of activesupport to the 3.x line to avoid deprecation
warnings that pop up with version 4.0.0.
