### PR TITLE
Adding rbx and jruby to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - jruby-19mode
+  - rbx-19mode


### PR DESCRIPTION
Why don't we build Cocaine on other rubies than MRI?
