### PR TITLE
Add options for each runner.

### DIFF
--- a/lib/cocaine/command_line.rb
+++ b/lib/cocaine/command_line.rb
@@ -32,6 +32,10 @@ module Cocaine
         @runner || best_runner
       end
 
+      def runner_options
+        @default_runner_options ||= {}
+      end
+
       def fake!
         @runner = FakeRunner.new
       end
@@ -62,6 +66,7 @@ module Cocaine
       @swallow_stderr    = @options.delete(:swallow_stderr)
       @expected_outcodes = @options.delete(:expected_outcodes) || [0]
       @environment       = @options.delete(:environment) || {}
+      @runner_options    = @options.delete(:runner_options) || {}
     end
 
     def command(interpolations = {})
@@ -119,11 +124,15 @@ module Cocaine
     end
 
     def execute(command)
-      runner.call(command, environment)
+      runner.call(command, environment, runner_options)
     end
 
     def environment
       self.class.environment.merge(@environment)
+    end
+
+    def runner_options
+      self.class.runner_options.merge(@runner_options)
     end
 
     def interpolate(pattern, interpolations)

--- a/lib/cocaine/command_line/runners/backticks_runner.rb
+++ b/lib/cocaine/command_line/runners/backticks_runner.rb
@@ -6,7 +6,7 @@ module Cocaine
   class CommandLine
     class BackticksRunner
 
-      def call(command, env = {})
+      def call(command, env = {}, options = {})
         with_modified_environment(env) do
           `#{command}`
         end

--- a/lib/cocaine/command_line/runners/fake_runner.rb
+++ b/lib/cocaine/command_line/runners/fake_runner.rb
@@ -10,7 +10,7 @@ module Cocaine
         @commands = []
       end
 
-      def call(command, env = {})
+      def call(command, env = {}, options = {})
         commands << [command, env]
         ""
       end

--- a/lib/cocaine/command_line/runners/popen_runner.rb
+++ b/lib/cocaine/command_line/runners/popen_runner.rb
@@ -3,9 +3,9 @@
 module Cocaine
   class CommandLine
     class PopenRunner
-      def call(command, env = {})
+      def call(command, env = {}, options = {})
         with_modified_environment(env) do
-          IO.popen(command, "r") do |pipe|
+          IO.popen(command, "r", options) do |pipe|
             pipe.read
           end
         end

--- a/lib/cocaine/command_line/runners/posix_runner.rb
+++ b/lib/cocaine/command_line/runners/posix_runner.rb
@@ -5,9 +5,10 @@ module Cocaine
     class PosixRunner
       if Cocaine::CommandLine.posix_spawn_available?
 
-        def call(command, env = {})
+        def call(command, env = {}, options = {})
           input, output = IO.pipe
-          pid = spawn(env, command, :out => output)
+          options[:out] = output
+          pid = spawn(env, command, options)
           output.close
           result = ""
           while partial_result = input.read(8192)

--- a/lib/cocaine/command_line/runners/process_runner.rb
+++ b/lib/cocaine/command_line/runners/process_runner.rb
@@ -5,9 +5,10 @@ module Cocaine
     class ProcessRunner
       if Process.respond_to?(:spawn)
 
-        def call(command, env = {})
+        def call(command, env = {}, options = {})
           input, output = IO.pipe
-          pid = spawn(env, command, :out => output)
+          options[:out] = output
+          pid = spawn(env, command, options)
           output.close
           result = input.read
           waitpid(pid)


### PR DESCRIPTION
Some runners like PosixRunner, ProcessRunner, PopenRunner supported specific options for their spawn method.
It solves a specific problem such as setup chdir for executing command.

For example command line

``` Ruby
cd some_path && zip -X0r file.epub mimetype META-INF OEBPS
```

can be runned as

``` Ruby
line = Cocaine::CommandLine.new("zip", "-X0r file.epub mimetype META-INF OEBPS", runner_options: {chdir: "some_path"})
line.run
```
