### PR TITLE
Ensuring exit status is always set, even when $? isn't

### DIFF
--- a/lib/cocaine/command_line.rb
+++ b/lib/cocaine/command_line.rb
@@ -77,7 +77,7 @@ module Cocaine
       rescue Errno::ENOENT => e
         raise Cocaine::CommandNotFoundError, e.message
       ensure
-        @exit_status = $?.exitstatus if $?.respond_to?(:exitstatus)
+        @exit_status = $?.respond_to?(:exitstatus) ? $?.exitstatus : 0
       end
       if @exit_status == 127
         raise Cocaine::CommandNotFoundError


### PR DESCRIPTION
Hi,

For an app I'm building ontop of cocaine, I'd like to be able to use the `FakeRunner` for testing in certain circumstances (for instance to log what commands will be run w/o actually running them). However, when I attempt to, the `$?` object is nil, and thus I get the following error:

```
/Users/drj/.rvm/gems/ruby-2.0.0-p247/gems/cocaine-0.5.3/lib/cocaine/command_line.rb:91:in `run': Command '<my command>' returned . Expected 0 (Cocaine::ExitStatusError)
```

It would seem that setting `@exit_status` conditionally, as you were, is unsafe since it is possible it will not be set. I have made the following (very small) change to set it to 0 when `$?` is unavailable. This means when using the FakeRunner (or if for some reason `$?` is not supported by the given runner), the exit status checking won't throw a fit.
