### PR TITLE
Save both STDOUT and STDERR when possible

### DIFF
--- a/lib/cocaine.rb
+++ b/lib/cocaine.rb
@@ -3,6 +3,8 @@
 require 'rbconfig'
 require 'cocaine/os_detector'
 require 'cocaine/command_line'
+require 'cocaine/command_line/output'
+require 'cocaine/command_line/multi_pipe'
 require 'cocaine/command_line/runners'
 require 'cocaine/exceptions'
 

--- a/lib/cocaine/command_line.rb
+++ b/lib/cocaine/command_line.rb
@@ -67,12 +67,11 @@ module Cocaine
     end
 
     def run(interpolations = {})
-      output = ''
       @exit_status = nil
       begin
         full_command = command(interpolations)
         log("#{colored("Command")} :: #{full_command}")
-        output = execute(full_command)
+        @output = execute(full_command)
       rescue Errno::ENOENT => e
         raise Cocaine::CommandNotFoundError, e.message
       ensure
@@ -86,12 +85,24 @@ module Cocaine
       unless @expected_outcodes.include?(@exit_status)
         message = [
           "Command '#{full_command}' returned #{@exit_status}. Expected #{@expected_outcodes.join(", ")}",
-          "Here is the command output:\n",
-          output
+          "Here is the command output: STDOUT:\n", command_output,
+          "\nSTDERR:\n", command_error_output
         ].join("\n")
         raise Cocaine::ExitStatusError, message
       end
-      output
+      command_output
+    end
+
+    def command_output
+      output.output
+    end
+
+    def command_error_output
+      output.error_output
+    end
+
+    def output
+      @output || Output.new
     end
 
     private

--- a/lib/cocaine/command_line/multi_pipe.rb
+++ b/lib/cocaine/command_line/multi_pipe.rb
@@ -1,0 +1,50 @@
+module Cocaine
+  class CommandLine
+    class MultiPipe
+      def initialize
+        @stdout_in, @stdout_out = IO.pipe
+        @stderr_in, @stderr_out = IO.pipe
+      end
+
+      def pipe_options
+        { out: @stdout_out, err: @stderr_out }
+      end
+
+      def output
+        Output.new(@stdout_output, @stderr_output)
+      end
+
+      def read_and_then(&block)
+        close_write
+        read
+        block.call
+        close_read
+      end
+
+      private
+
+      def close_write
+        @stdout_out.close
+        @stderr_out.close
+      end
+
+      def read
+        @stdout_output = read_stream(@stdout_in)
+        @stderr_output = read_stream(@stderr_in)
+      end
+
+      def close_read
+        @stdout_in.close
+        @stderr_in.close
+      end
+
+      def read_stream(io)
+        result = ""
+        while partial_result = io.read(8192)
+          result << partial_result
+        end
+        result
+      end
+    end
+  end
+end

--- a/lib/cocaine/command_line/output.rb
+++ b/lib/cocaine/command_line/output.rb
@@ -1,0 +1,12 @@
+class Cocaine::CommandLine::Output
+  def initialize(output = nil, error_output = nil)
+    @output = output
+    @error_output = error_output
+  end
+
+  attr_reader :output, :error_output
+
+  def to_s
+    output.to_s
+  end
+end

--- a/lib/cocaine/command_line/runners/backticks_runner.rb
+++ b/lib/cocaine/command_line/runners/backticks_runner.rb
@@ -15,7 +15,7 @@ module Cocaine
 
       def call(command, env = {}, options = {})
         with_modified_environment(env) do
-          `#{command}`
+          Output.new(`#{command}`)
         end
       end
 

--- a/lib/cocaine/command_line/runners/fake_runner.rb
+++ b/lib/cocaine/command_line/runners/fake_runner.rb
@@ -19,13 +19,12 @@ module Cocaine
 
       def call(command, env = {}, options = {})
         commands << [command, env]
-        ""
+        Output.new("")
       end
 
       def ran?(predicate_command)
-        @commands.any?{|(command, env)| command =~ Regexp.new(predicate_command) }
+        @commands.any?{|(command, _)| command =~ Regexp.new(predicate_command) }
       end
-
     end
   end
 end

--- a/lib/cocaine/command_line/runners/popen_runner.rb
+++ b/lib/cocaine/command_line/runners/popen_runner.rb
@@ -14,7 +14,7 @@ module Cocaine
       def call(command, env = {}, options = {})
         with_modified_environment(env) do
           IO.popen(command, "r", options) do |pipe|
-            pipe.read
+            Output.new(pipe.read)
           end
         end
       end

--- a/lib/cocaine/command_line/runners/process_runner.rb
+++ b/lib/cocaine/command_line/runners/process_runner.rb
@@ -16,14 +16,12 @@ module Cocaine
       end
 
       def call(command, env = {}, options = {})
-        input, output = IO.pipe
-        options[:out] = output
-        pid = spawn(env, command, options)
-        output.close
-        result = input.read
-        waitpid(pid)
-        input.close
-        result
+        pipe = MultiPipe.new
+        pid = spawn(env, command, options.merge(pipe.pipe_options))
+        pipe.read_and_then do
+          waitpid(pid)
+        end
+        pipe.output
       end
 
       private

--- a/spec/cocaine/command_line/output_spec.rb
+++ b/spec/cocaine/command_line/output_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Cocaine::CommandLine::Output do
+  it 'holds an input and error stream' do
+    output = Cocaine::CommandLine::Output.new(:a, :b)
+    expect(output.output).to eq :a
+    expect(output.error_output).to eq :b
+  end
+
+  it 'calls #to_s on the output when you call #to_s on it' do
+    output = Cocaine::CommandLine::Output.new(:a, :b)
+    expect(output.to_s).to eq 'a'
+  end
+end

--- a/spec/cocaine/command_line/runners/backticks_runner_spec.rb
+++ b/spec/cocaine/command_line/runners/backticks_runner_spec.rb
@@ -4,12 +4,14 @@ describe Cocaine::CommandLine::BackticksRunner do
   if Cocaine::CommandLine::BackticksRunner.supported?
     it_behaves_like 'a command that does not block'
 
-    it 'runs the command given' do
-      subject.call("echo hello").should == "hello\n"
+    it 'runs the command given and captures the output in an Output' do
+      output = subject.call("echo hello")
+      expect(output).to have_output "hello\n"
     end
 
     it 'modifies the environment and runs the command given' do
-      subject.call("echo $yes", {"yes" => "no"}).should == "no\n"
+      output = subject.call("echo $yes", {"yes" => "no"})
+      expect(output).to have_output "no\n"
     end
 
     it 'sets the exitstatus when a command completes' do

--- a/spec/cocaine/command_line/runners/popen_runner_spec.rb
+++ b/spec/cocaine/command_line/runners/popen_runner_spec.rb
@@ -4,12 +4,14 @@ describe Cocaine::CommandLine::PopenRunner do
   if Cocaine::CommandLine::PopenRunner.supported?
     it_behaves_like 'a command that does not block'
 
-    it 'runs the command given' do
-      subject.call("echo hello").should == "hello\n"
+    it 'runs the command given and captures the output in an Output' do
+      output = subject.call("echo hello")
+      expect(output).to have_output "hello\n"
     end
 
     it 'modifies the environment and runs the command given' do
-      subject.call("echo $yes", {"yes" => "no"}).should == "no\n"
+      output = subject.call("echo $yes", {"yes" => "no"})
+      expect(output).to have_output "no\n"
     end
 
     it 'sets the exitstatus when a command completes' do

--- a/spec/cocaine/command_line/runners/posix_runner_spec.rb
+++ b/spec/cocaine/command_line/runners/posix_runner_spec.rb
@@ -4,12 +4,19 @@ describe Cocaine::CommandLine::PosixRunner do
   if Cocaine::CommandLine::PosixRunner.supported?
     it_behaves_like 'a command that does not block'
 
-    it 'runs the command given' do
-      subject.call("echo hello").should == "hello\n"
+    it 'runs the command given and captures the output' do
+      output = subject.call("echo hello")
+      expect(output).to have_output "hello\n"
+    end
+
+    it 'runs the command given and captures the error output' do
+      output = subject.call("echo hello 1>&2")
+      expect(output).to have_error_output "hello\n"
     end
 
     it 'modifies the environment and runs the command given' do
-      subject.call("echo $yes", {"yes" => "no"}).should == "no\n"
+      output = subject.call("echo $yes", {"yes" => "no"})
+      expect(output).to have_output "no\n"
     end
 
     it 'sets the exitstatus when a command completes' do

--- a/spec/cocaine/command_line/runners/posix_runner_spec.rb
+++ b/spec/cocaine/command_line/runners/posix_runner_spec.rb
@@ -25,5 +25,16 @@ describe Cocaine::CommandLine::PosixRunner do
       subject.call("ruby -e 'exit 5'")
       $?.exitstatus.should == 5
     end
+
+    it "runs the command it's given and allows access to stderr afterwards" do
+      cmd = Cocaine::CommandLine.new(
+        "ruby",
+        "-e '$stdout.puts %{hello}; $stderr.puts %{goodbye}'",
+        :swallow_stderr => false
+      )
+      cmd.run
+      expect(cmd.command_output).to eq "hello\n"
+      expect(cmd.command_error_output).to eq "goodbye\n"
+    end
   end
 end

--- a/spec/cocaine/command_line/runners/process_runner_spec.rb
+++ b/spec/cocaine/command_line/runners/process_runner_spec.rb
@@ -4,12 +4,19 @@ describe Cocaine::CommandLine::ProcessRunner do
   if Cocaine::CommandLine::ProcessRunner.supported?
     it_behaves_like "a command that does not block"
 
-    it 'runs the command given' do
-      subject.call("echo hello").should == "hello\n"
+    it 'runs the command given and captures the output' do
+      output = subject.call("echo hello")
+      expect(output).to have_output "hello\n"
+    end
+
+    it 'runs the command given and captures the error output' do
+      output = subject.call("echo hello 1>&2")
+      expect(output).to have_error_output "hello\n"
     end
 
     it 'modifies the environment and runs the command given' do
-      subject.call("echo $yes", {"yes" => "no"}).should == "no\n"
+      output = subject.call("echo $yes", {"yes" => "no"})
+      expect(output).to have_output "no\n"
     end
 
     it 'sets the exitstatus when a command completes' do

--- a/spec/cocaine/command_line/runners/process_runner_spec.rb
+++ b/spec/cocaine/command_line/runners/process_runner_spec.rb
@@ -25,5 +25,16 @@ describe Cocaine::CommandLine::ProcessRunner do
       subject.call("ruby -e 'exit 5'")
       $?.exitstatus.should == 5
     end
+
+    it "runs the command it's given and allows access to stderr afterwards" do
+      cmd = Cocaine::CommandLine.new(
+        "ruby",
+        "-e '$stdout.puts %{hello}; $stderr.puts %{goodbye}'",
+        :swallow_stderr => false
+      )
+      cmd.run
+      expect(cmd.command_output).to eq "hello\n"
+      expect(cmd.command_error_output).to eq "goodbye\n"
+    end
   end
 end

--- a/spec/cocaine/command_line_spec.rb
+++ b/spec/cocaine/command_line_spec.rb
@@ -154,17 +154,6 @@ describe Cocaine::CommandLine do
     expect(cmd.command_output).to eq "hello\n"
   end
 
-  it "runs the command it's given and allows access to stderr afterwards" do
-    cmd = Cocaine::CommandLine.new(
-      "ruby",
-      "-e '$stdout.puts %{hello}; $stderr.puts %{goodbye}'",
-      :swallow_stderr => false
-    )
-    cmd.run
-    expect(cmd.command_output).to eq "hello\n"
-    expect(cmd.command_error_output).to eq "goodbye\n"
-  end
-
   it "colorizes the output to a tty" do
     logger = FakeLogger.new(:tty => true)
     Cocaine::CommandLine.new("echo", "'Logging!' :foo", :logger => logger).run(:foo => "bar")

--- a/spec/cocaine/command_line_spec.rb
+++ b/spec/cocaine/command_line_spec.rb
@@ -143,12 +143,26 @@ describe Cocaine::CommandLine do
     cmd.command.should == "convert a.jpg b.png 2>NUL"
   end
 
-  it "runs the command it's given and return the output" do
-    cmd = Cocaine::CommandLine.new("convert", "a.jpg b.png", :swallow_stderr => false)
-    cmd.stubs(:execute).with("convert a.jpg b.png").returns(:correct_value)
-    with_exitstatus_returning(0) do
-      cmd.run.should == :correct_value
-    end
+  it "runs the command it's given and returns the output" do
+    cmd = Cocaine::CommandLine.new("echo", "hello", :swallow_stderr => false)
+    expect(cmd.run).to eq "hello\n"
+  end
+
+  it "runs the command it's given and allows access to stdout afterwards" do
+    cmd = Cocaine::CommandLine.new("echo", "hello", :swallow_stderr => false)
+    cmd.run
+    expect(cmd.command_output).to eq "hello\n"
+  end
+
+  it "runs the command it's given and allows access to stderr afterwards" do
+    cmd = Cocaine::CommandLine.new(
+      "ruby",
+      "-e '$stdout.puts %{hello}; $stderr.puts %{goodbye}'",
+      :swallow_stderr => false
+    )
+    cmd.run
+    expect(cmd.command_output).to eq "hello\n"
+    expect(cmd.command_error_output).to eq "goodbye\n"
   end
 
   it "colorizes the output to a tty" do

--- a/spec/cocaine/errors_spec.rb
+++ b/spec/cocaine/errors_spec.rb
@@ -1,47 +1,40 @@
 require 'spec_helper'
 
 describe "When an error happens" do
-  it "raises a CommandLineError if the result code from the command isn't expected" do
-    cmd = Cocaine::CommandLine.new("convert", "a.jpg b.png", :swallow_stderr => false)
-    cmd.stubs(:execute).with("convert a.jpg b.png").returns(:correct_value)
+  it "raises a CommandLineError if the result code command isn't expected" do
+    cmd = Cocaine::CommandLine.new("echo", "hello")
+    cmd.stubs(:execute)
     with_exitstatus_returning(1) do
-      lambda do
-        cmd.run
-      end.should raise_error(Cocaine::CommandLineError)
+      lambda { cmd.run }.should raise_error(Cocaine::CommandLineError)
     end
   end
 
   it "does not raise if the result code is expected, even if nonzero" do
-    cmd = Cocaine::CommandLine.new("convert",
-                                   "a.jpg b.png",
-                                   :expected_outcodes => [0, 1],
-                                   :swallow_stderr => false)
-    cmd.stubs(:execute).with("convert a.jpg b.png").returns(:correct_value)
+    cmd = Cocaine::CommandLine.new("echo", "hello", expected_outcodes: [0, 1])
+    cmd.stubs(:execute)
     with_exitstatus_returning(1) do
-      lambda do
-        cmd.run
-      end.should_not raise_error
+      lambda { cmd.run }.should_not raise_error
     end
   end
 
   it "adds command output to exception message if the result code is nonzero" do
-    cmd = Cocaine::CommandLine.new("convert",
-                                   "a.jpg b.png",
-                                   :swallow_stderr => false)
+    cmd = Cocaine::CommandLine.new("echo", "hello")
     error_output = "Error 315"
-    cmd.stubs(:execute).with("convert a.jpg b.png").returns(error_output)
+    cmd.
+      stubs(:execute).
+      returns(Cocaine::CommandLine::Output.new("", error_output))
     with_exitstatus_returning(1) do
       begin
         cmd.run
       rescue Cocaine::ExitStatusError => e
-        e.message.should =~ /#{error_output}/
+        e.message.should =~ /STDERR:\s+#{error_output}/
       end
     end
   end
 
-  it 'passes error message to the exception when command fails with Errno::ENOENT' do
+  it 'passes the error message to the exception when command is not found' do
     cmd = Cocaine::CommandLine.new('test', '')
-    cmd.stubs(:execute).with('test').raises(Errno::ENOENT.new("not found"))
+    cmd.stubs(:execute).raises(Errno::ENOENT.new("not found"))
     begin
       cmd.run
     rescue Cocaine::CommandNotFoundError => e
@@ -58,7 +51,7 @@ describe "When an error happens" do
     cmd.exit_status.should == 1
   end
 
-  it "does not blow up if running the command errored before the actual execution" do
+  it "does not blow up if running the command errored before execution" do
     assuming_no_processes_have_been_run
     command = Cocaine::CommandLine.new("echo", ":hello_world")
     command.stubs(:command).raises("An Error")

--- a/spec/support/have_output.rb
+++ b/spec/support/have_output.rb
@@ -1,0 +1,11 @@
+RSpec::Matchers.define :have_output do |expected|
+  match do |actual|
+    actual.output == expected
+  end
+end
+
+RSpec::Matchers.define :have_error_output do |expected|
+  match do |actual|
+    actual.error_output == expected
+  end
+end

--- a/spec/support/nonblocking_examples.rb
+++ b/spec/support/nonblocking_examples.rb
@@ -6,7 +6,7 @@ shared_examples_for "a command that does not block" do
     Timeout.timeout(5) do
       output = subject.call("cat '#{garbage_file.path}'")
       $?.exitstatus.should == 0
-      output.length.should == 10 * 1024 * 1024
+      output.output.length.should == 10 * 1024 * 1024
     end
 
     garbage_file.close


### PR DESCRIPTION
Create an Output object that stores the returned output and error
streams from the executed commands. Because of the implementation
details, this will only work for the ProcessRunner and PosixRunner.
Backticks and IO.popen don't have capabilities for this.

There is a good bit of duplication in those two runners and I can't think of a good way to get rid of it, given the requirement of the `waitpid` call in there. There is also a good bit of duplication between the runners themselves. All told, though, this seems like it might be too much hassle and complication for the feature. I'm unsure if I would pull this if I were handed it.