### PR TITLE
Use '==' for assertions against true and false

### DIFF
--- a/spec/cocaine/command_line/runners/fake_runner_spec.rb
+++ b/spec/cocaine/command_line/runners/fake_runner_spec.rb
@@ -10,13 +10,13 @@ describe Cocaine::CommandLine::FakeRunner do
   it 'can tell if a command was run' do
     subject.call("some command", :environment)
     subject.call("other command", :other_environment)
-    subject.ran?("some command").should == true
-    subject.ran?("no command").should == false
+    subject.ran?("some command").should eq true
+    subject.ran?("no command").should eq false
   end
 
   it 'can tell if a command was run even if shell options were set' do
     subject.call("something 2>/dev/null", :environment)
-    subject.ran?("something").should == true
+    subject.ran?("something").should eq true
   end
 
 end


### PR DESCRIPTION
This fixes tests breaking with non-monkey-patched 'true' and 'false' objects.
