### PR TITLE
Don't use ClimateControl when it's not necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,13 @@ try to use `PopenRunner`:
 Cocaine::CommandLine.runner = Cocaine::CommandLine::PopenRunner.new
 ```
 
+## Thread Safety
+
+Cocaine should be thread safe. As discussed [here, in this climate_control
+thread](https://github.com/thoughtbot/climate_control/pull/11), climate_control,
+which modifies the environment under which commands are run for the
+BackticksRunner and PopenRunner, is thread-safe but not reentrant. Please let us
+know if you find this is ever not the case.
 
 ## REE
 

--- a/lib/cocaine.rb
+++ b/lib/cocaine.rb
@@ -1,6 +1,7 @@
 # coding: UTF-8
 
 require 'rbconfig'
+require 'cocaine/os_detector'
 require 'cocaine/command_line'
 require 'cocaine/command_line/runners'
 require 'cocaine/exceptions'

--- a/lib/cocaine/command_line/runners/popen_runner.rb
+++ b/lib/cocaine/command_line/runners/popen_runner.rb
@@ -22,11 +22,23 @@ module Cocaine
       private
 
       def env_command(command)
-        if Cocaine::CommandLine.java?
-          "env #{command}"
-        else
+        windows_command(command) || java_command(command) || default_command(command)
+      end
+
+      def windows_command(command)
+        if OS.windows?
           command
         end
+      end
+
+      def java_command(command)
+        if OS.java?
+          "env #{command}"
+        end
+      end
+
+      def default_command(command)
+        command
       end
 
       def with_modified_environment(env, &block)

--- a/lib/cocaine/command_line/runners/posix_runner.rb
+++ b/lib/cocaine/command_line/runners/posix_runner.rb
@@ -11,7 +11,7 @@ module Cocaine
       end
 
       def self.supported?
-        available? && !Cocaine::CommandLine.java?
+        available? && !OS.java?
       end
 
       def supported?
@@ -21,17 +21,15 @@ module Cocaine
       def call(command, env = {}, options = {})
         input, output = IO.pipe
         options[:out] = output
-        with_modified_environment(env) do
-          pid = spawn(env, command, options)
-          output.close
-          result = ""
-          while partial_result = input.read(8192)
-            result << partial_result
-          end
-          waitpid(pid)
-          input.close
-          result
+        pid = spawn(env, command, options)
+        output.close
+        result = ""
+        while partial_result = input.read(8192)
+          result << partial_result
         end
+        waitpid(pid)
+        input.close
+        result
       end
 
       private
@@ -42,10 +40,6 @@ module Cocaine
 
       def waitpid(pid)
         Process.waitpid(pid)
-      end
-
-      def with_modified_environment(env, &block)
-        ClimateControl.modify(env, &block)
       end
 
     end

--- a/lib/cocaine/command_line/runners/process_runner.rb
+++ b/lib/cocaine/command_line/runners/process_runner.rb
@@ -8,7 +8,7 @@ module Cocaine
       end
 
       def self.supported?
-        available? && !Cocaine::CommandLine.java?
+        available? && !OS.java?
       end
 
       def supported?
@@ -18,14 +18,12 @@ module Cocaine
       def call(command, env = {}, options = {})
         input, output = IO.pipe
         options[:out] = output
-        with_modified_environment(env) do
-          pid = spawn(env, command, options)
-          output.close
-          result = input.read
-          waitpid(pid)
-          input.close
-          result
-        end
+        pid = spawn(env, command, options)
+        output.close
+        result = input.read
+        waitpid(pid)
+        input.close
+        result
       end
 
       private
@@ -38,10 +36,6 @@ module Cocaine
         Process.waitpid(pid)
       rescue Errno::ECHILD
         # In JRuby, waiting on a finished pid raises.
-      end
-
-      def with_modified_environment(env, &block)
-        ClimateControl.modify(env, &block)
       end
 
     end

--- a/lib/cocaine/os_detector.rb
+++ b/lib/cocaine/os_detector.rb
@@ -1,0 +1,27 @@
+# coding: UTF-8
+
+module Cocaine
+  class OSDetector
+    def java?
+      arch =~ /java/
+    end
+
+    def unix?
+      RbConfig::CONFIG['host_os'] !~ /mswin|mingw/
+    end
+
+    def windows?
+      !unix?
+    end
+
+    def path_separator
+      File::PATH_SEPARATOR
+    end
+
+    def arch
+      RUBY_PLATFORM
+    end
+  end
+
+  OS = OSDetector.new
+end

--- a/spec/cocaine/os_detector_spec.rb
+++ b/spec/cocaine/os_detector_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Cocaine::OSDetector do
+  it "detects that the system is unix" do
+    on_unix!
+    Cocaine::OS.should be_unix
+  end
+
+  it "detects that the system is windows" do
+    on_windows!
+    Cocaine::OS.should be_windows
+  end
+
+  it "detects that the system is windows (mingw)" do
+    on_mingw!
+    Cocaine::OS.should be_windows
+  end
+
+  it "detects that the current Ruby is on Java" do
+    on_java!
+    Cocaine::OS.should be_java
+  end
+end

--- a/spec/cocaine/runners_spec.rb
+++ b/spec/cocaine/runners_spec.rb
@@ -72,7 +72,7 @@ describe 'When running an executable in the supplemental path' do
   end
 
   after do
-    FileUtils.rm_f(Cocaine::CommandLine.path + 'ls')
+    FileUtils.rm_f("#{Cocaine::CommandLine.path}/ls")
   end
 
   [

--- a/spec/support/stub_os.rb
+++ b/spec/support/stub_os.rb
@@ -1,14 +1,21 @@
 module StubOS
   def on_windows!
     stub_os('mswin')
+    Cocaine::OS.stubs(:path_separator).returns(";")
   end
 
   def on_unix!
     stub_os('darwin11.0.0')
+    Cocaine::OS.stubs(:path_separator).returns(":")
   end
 
   def on_mingw!
     stub_os('mingw')
+    Cocaine::OS.stubs(:path_separator).returns(";")
+  end
+
+  def on_java!
+    Cocaine::OS.stubs(:arch).returns("universal-java1.7")
   end
 
   def stub_os(host_string)


### PR DESCRIPTION
The ProcessRunner and PosixRunner are perfectly capable of taking an
environment hash. This means there's no reason to use ClimateControl to
modify the environment beforehand. In order to find custom binaries, we
can modify the PATH on the command line -- yes, for both Unix and
Windows.

Unix commandlines use the normal `PATH=/new/path:$PATH cmd` syntax.
Windows uses `SET PATH=C:\new\path;%PATH% & cmd` instead.

The difference between then and now is that I found out that you can
actually separate commands in Windows with `&` (see
http://support.microsoft.com/kb/279253).

As a result of this the `supplemental_environment` isn't modified when
the `path` is modified. We keep the path in memory as a
`Cocaine::OS.path_separator`-separated string.

In addition, this commit cleans up the OS detection slightly, moving it
to a new class. In the future, we can do things like telling instead of
asking.

The result of all this is that the `ProcessRunner` and `PosixRunner`
should be thread-safe, since we're not mucking around with the `ENV`
when we run stuff anymore. This will make the high-throughput users of
Paperclip happy, since they shouldn't see clobbering issues like they
did before. I tested this by running the code supplied by @maxim,
https://github.com/thoughtbot/paperclip/issues/1709#issuecomment-64812263,
with the unmodified cocaine 0.5.4 gem and with this commit in place. It
failed in a few seconds before and ran for as long as I wanted after.

This also might fix a bug? Previously, on Java on Windows, commands
would be called prefixed with `env`, which doesn't exist on Windows. No
one complained, though, so you can guess how popular Java on Windows is
(or I'm completely screwing up).  Now we look for Windows first, then
use `env` with Java, and then Unix like normal.
