### PR TITLE
gemspec: use HTTPS for homepage URL

### DIFF
--- a/cocaine.gemspec
+++ b/cocaine.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.platform          = Gem::Platform::RUBY
   s.author            = "Jon Yurek"
   s.email             = "jyurek@thoughtbot.com"
-  s.homepage          = "http://github.com/thoughtbot/cocaine"
+  s.homepage          = "https://github.com/thoughtbot/cocaine"
   s.summary           = "A small library for doing (command) lines"
   s.description       = "A small library for doing (command) lines"
   s.license           = "MIT"


### PR DESCRIPTION
This pull request updates the cocaine gemspec metadata to use an encrypted HTTPS URL for the gem's homepage.
