### PR TITLE
Gemfile: use HTTPS for rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gemspec
 


### PR DESCRIPTION
Use HTTPS so users' connections to the rubygems.org server will be verified with SSL.
