### PR TITLE
shell_quote now converts argument to a string automatically

### DIFF
--- a/lib/cocaine/command_line.rb
+++ b/lib/cocaine/command_line.rb
@@ -166,6 +166,11 @@ module Cocaine
 
     def shell_quote(string)
       return "" if string.nil?
+      if string.respond_to? :to_s
+        string = string.to_s
+      else
+        raise ArgumentError, "Must be a String or have the ability to convert to a String."
+      end
       if OS.unix?
         if string.empty?
           "''"

--- a/lib/cocaine/command_line.rb
+++ b/lib/cocaine/command_line.rb
@@ -168,8 +168,6 @@ module Cocaine
       return "" if string.nil?
       if string.respond_to? :to_s
         string = string.to_s
-      else
-        raise ArgumentError, "Must be a String or have the ability to convert to a String."
       end
       if OS.unix?
         if string.empty?

--- a/lib/cocaine/command_line.rb
+++ b/lib/cocaine/command_line.rb
@@ -166,9 +166,8 @@ module Cocaine
 
     def shell_quote(string)
       return "" if string.nil?
-      if string.respond_to? :to_s
-        string = string.to_s
-      end
+      string = string.to_s if string.respond_to? :to_s
+
       if OS.unix?
         if string.empty?
           "''"

--- a/spec/cocaine/command_line_spec.rb
+++ b/spec/cocaine/command_line_spec.rb
@@ -126,6 +126,12 @@ describe Cocaine::CommandLine do
     cmd.command.should == "convert 'a.jpg' xc:black 'b.jpg'"
   end
 
+  it 'handles symbols in user supplied values' do
+    cmd = Cocaine::CommandLine.new("echo", ":foo")
+    command_string = cmd.command(:foo => :bar)
+    command_string.should == "echo 'bar'"
+  end
+
   it "can redirect stderr to the bit bucket if requested" do
     cmd = Cocaine::CommandLine.new("convert",
                                    "a.jpg b.png",


### PR DESCRIPTION
Previously, shell_quote couldn't handle anything besides strings (like symbols) due to it's use of String#split. It now attempts to run to_s on the argument or it raises an ArgumentError.