### PR TITLE
Don't require "posix/spawn" every time PosixRunner#available? is called

### DIFF
--- a/lib/cocaine/command_line/runners/posix_runner.rb
+++ b/lib/cocaine/command_line/runners/posix_runner.rb
@@ -4,10 +4,9 @@ module Cocaine
   class CommandLine
     class PosixRunner
       def self.available?
-        require 'posix/spawn'
-        true
-      rescue LoadError
-        false
+        return @available unless @available.nil?
+
+        @available = posix_spawn_gem_available?
       end
 
       def self.supported?
@@ -42,6 +41,14 @@ module Cocaine
         Process.waitpid(pid)
       end
 
+      def self.posix_spawn_gem_available?
+        require 'posix/spawn'
+        true
+      rescue
+        false
+      end
+
+      private_class_method :posix_spawn_gem_available?
     end
   end
 end


### PR DESCRIPTION
Fixes #79 "Optimization proposal for Cocaine::CommandLine::PosixRunner.available?".