### PR TITLE
Fix posix_spawn_gem_available?

### DIFF
--- a/lib/cocaine/command_line/runners/posix_runner.rb
+++ b/lib/cocaine/command_line/runners/posix_runner.rb
@@ -44,7 +44,7 @@ module Cocaine
       def self.posix_spawn_gem_available?
         require 'posix/spawn'
         true
-      rescue
+      rescue LoadError
         false
       end
 


### PR DESCRIPTION
fixes #82

Explicitly rescue `LoadError` instead of failing with "cannot load such file -- posix/spawn".