### PR TITLE
Add rbx-2 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ rvm:
   - 2.0.0
   - 2.1.5
   - jruby-19mode
+  - rbx-2


### PR DESCRIPTION
The 'rbx-2' designation will run on the most recent Rubinius 2.x release.

If you experience failures on Rubinius, adding rbx-2 to `allow_failures` on Travis rather than removing it completely gives us and the project valuable feedback.

Thanks!