### PR TITLE
require pathname during tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'timeout'
 require 'tempfile'
 require 'pry'
 require 'thread'
+require 'pathname'
 
 begin; require 'active_support/logger'; rescue LoadError; end
 begin; require 'active_support/buffered_logger'; rescue LoadError; end


### PR DESCRIPTION
Commit ba7630ab83945a4eb11d3e0a30fe3664bd3d9a84 introduced a dependency on the pathname library. When running the tests outside of Bundler on Fedora 23, Ruby cannot find this library:

```
  $ rspec -Ilib spec

  ... snip ...

     NameError:
       uninitialized constant Pathname
```

Add the gem to the `spec_helper` to ensure that Ruby loads it in all cases.