### PR TITLE
Handle expected outcodes as a range

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ rvm:
   - 2.1.5
   - jruby-19mode
   - rbx-2
+before_install:
+  - gem update bundler

--- a/lib/cocaine/command_line.rb
+++ b/lib/cocaine/command_line.rb
@@ -84,7 +84,8 @@ module Cocaine
 
       unless @expected_outcodes.include?(@exit_status)
         message = [
-          "Command '#{full_command}' returned #{@exit_status}. Expected #{@expected_outcodes.join(", ")}",
+          "Command '#{full_command}' returned #{@exit_status}. " \
+          "Expected #{@expected_outcodes.to_a.join(", ")}",
           "Here is the command output: STDOUT:\n", command_output,
           "\nSTDERR:\n", command_error_output
         ].join("\n")

--- a/lib/cocaine/command_line.rb
+++ b/lib/cocaine/command_line.rb
@@ -85,7 +85,7 @@ module Cocaine
       unless @expected_outcodes.include?(@exit_status)
         message = [
           "Command '#{full_command}' returned #{@exit_status}. " \
-          "Expected #{@expected_outcodes.to_a.join(", ")}",
+          "Expected #{@expected_outcodes.to_a.join(', ')}",
           "Here is the command output: STDOUT:\n", command_output,
           "\nSTDERR:\n", command_error_output
         ].join("\n")

--- a/spec/cocaine/errors_spec.rb
+++ b/spec/cocaine/errors_spec.rb
@@ -32,6 +32,21 @@ describe "When an error happens" do
     end
   end
 
+  it "adds command output to exception message if the result code is not in range" do
+    cmd = Cocaine::CommandLine.new("echo", "hello", expected_outcodes: (0..1))
+    error_output = "Error 315"
+    cmd.
+      stubs(:execute).
+      returns(Cocaine::CommandLine::Output.new("", error_output))
+    with_exitstatus_returning(2) do
+      begin
+        cmd.run
+      rescue Cocaine::ExitStatusError => e
+        expect(e.message).to match /STDERR:\s+#{error_output}/
+      end
+    end
+  end
+
   it 'passes the error message to the exception when command is not found' do
     cmd = Cocaine::CommandLine.new('test', '')
     cmd.stubs(:execute).raises(Errno::ENOENT.new("not found"))

--- a/spec/cocaine/errors_spec.rb
+++ b/spec/cocaine/errors_spec.rb
@@ -32,7 +32,8 @@ describe "When an error happens" do
     end
   end
 
-  it "adds command output to exception message if the result code is not in range" do
+  it "adds command output to exception message if the result code is not in " \
+     "range of expected outcodes" do
     cmd = Cocaine::CommandLine.new("echo", "hello", expected_outcodes: (0..1))
     error_output = "Error 315"
     cmd.


### PR DESCRIPTION
This change allows `expected_outcodes` to be passed as a `Range`. Previously this would fail as `join` was called when formatting the output message returning an undefined method error.

`NoMethodError: undefined method 'join' for 0..1:Range`
